### PR TITLE
refactor: rename electrical components rpc methods to align with the new naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 The Frequenz Platform Assets API allows for the retrieval of platform assets information. Unlike CRUD-centric 
 APIs, the focus here is on accessing already registered assets ranging from microgrids and gridpools to 
-individual components within these structures, such as sensors and their respective electrical connections.
+individual electrical components within these structures, such as sensors and their respective electrical connections.
 
 ## Objective
 
@@ -19,7 +19,7 @@ across multiple microgrids, optimizing spot market trading based on real-time gr
 ## Key Features
 
 - Asset Retrieval: Provides programmatic access to a wide range of platform assets, including microgrids, 
-   gridpools, components, sensors, and connections.
+   gridpools, electrical components, and connections.
 - Data-Driven Optimization: Facilitates the development of applications that can read asset information and 
    statuses for real-time decision making.
 - Scheduling Insights: Enables applications to understand and adapt to gridpool schedules for improved spot 
@@ -27,7 +27,7 @@ across multiple microgrids, optimizing spot market trading based on real-time gr
 
 ## Scope and Limitations
 
-- Retrieval of detailed asset data for various entities such as microgrids, gridpools, and their components.
+- Retrieval of detailed asset data for various entities such as microgrids, gridpools, and their electrical components.
 - Enabling advanced analytics and data-driven decisions for cloud applications.
 - Read-Only: The API is designed for data retrieval and doesn't support CRUD operations for assets.
 - Dependence on Platform: The quality and timeliness of data are dependent on the capabilities of the underlying platform.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,16 +2,14 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+Adjusted the RPC names to align with the new naming convention, and updated the `frequenz-api-common` dependency.
+
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- Update the `frequenz-api-common` dependency
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- Renamed `ListMicrogridComponents` to `ListMicrogridElectricalComponents` and `ListMicrogridComponentConnections` to `ListMicrogridElectricalComponentConnections`.
 
-## Bug Fixes
-
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/proto/frequenz/api/assets/v1/assets.proto
+++ b/proto/frequenz/api/assets/v1/assets.proto
@@ -14,7 +14,7 @@ syntax = "proto3";
 
 package frequenz.api.assets.v1;
 
-import "frequenz/api/common/v1/microgrid/components/components.proto";
+import "frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto";
 import "frequenz/api/common/v1/microgrid/microgrid.proto";
 
 // Service providing access to manage and retrieve information
@@ -58,7 +58,7 @@ message ListMicrogridElectricalComponentsRequest {
   repeated uint64 component_ids = 2;
 
   // Return components that have the specified categories only.
-  repeated frequenz.api.common.v1.microgrid.components.ComponentCategory categories = 3;
+  repeated frequenz.api.common.v1.microgrid.electrical_components.ElectricalComponentCategory categories = 3;
 }
 
 // A message containing a list of electrical components.
@@ -67,7 +67,7 @@ message ListMicrogridElectricalComponentsResponse {
   uint64 microgrid_id = 1;
   
   // List of electrical components matching the filter criteria.
-  repeated frequenz.api.common.v1.microgrid.components.Component components = 2;
+  repeated frequenz.api.common.v1.microgrid.electrical_components.ElectricalComponent components = 2;
 }
 
 // ListMicrogridElectricalComponentConnectionsRequest is used for filtering and listing
@@ -115,5 +115,5 @@ message ListMicrogridElectricalComponentConnectionsResponse {
   uint64 microgrid_id = 1;
   
   // Contains the list of connections that match the filtering criteria.
-  repeated frequenz.api.common.v1.microgrid.components.ComponentConnection connections =2;
+  repeated frequenz.api.common.v1.microgrid.electrical_components.ElectricalComponentConnection connections =2;
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.6.3, < 0.7.0",
+  "frequenz-api-common @ git+https://github.com/frequenz-floss/frequenz-api-common.git@2e89add6a16d42b23612f0f791a499919f3738ed",
   # We can't widen beyond the current value unless we bump the minimum
   # requirements too because of protobuf cross-version runtime guarantees:
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#major


### PR DESCRIPTION
This pull request introduces updates to the API to standardize terminology and improve clarity by replacing "components" with "electrical components" across documentation, protobuf definitions, and related files. Additionally, a submodule update is included to align with these changes.

### Terminology Standardization and API Updates:
* Updated `README.md` to replace references to "components" with "electrical components" for better specificity and consistency. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R30)
* Modified `proto/frequenz/api/assets/v1/assets.proto` to rename RPC methods and message definitions:
  - `ListMicrogridComponents` and `ListMicrogridComponentConnections` renamed to `ListMicrogridElectricalComponents` and `ListMicrogridElectricalComponentConnections`, respectively. [[1]](diffhunk://#diff-6276ba75449ae7839646f935f198edd81c16f6bf180d9a95b83b5fe50f25e80dL27-R34) [[2]](diffhunk://#diff-6276ba75449ae7839646f935f198edd81c16f6bf180d9a95b83b5fe50f25e80dL52-R52) [[3]](diffhunk://#diff-6276ba75449ae7839646f935f198edd81c16f6bf180d9a95b83b5fe50f25e80dL97-R96) [[4]](diffhunk://#diff-6276ba75449ae7839646f935f198edd81c16f6bf180d9a95b83b5fe50f25e80dL111-R118)
  - Updated field types and imports to use `ElectricalComponent` and `ElectricalComponentCategory` from `electrical_components.proto` instead of `components.proto`. [[1]](diffhunk://#diff-6276ba75449ae7839646f935f198edd81c16f6bf180d9a95b83b5fe50f25e80dL62-R71) [[2]](diffhunk://#diff-6276ba75449ae7839646f935f198edd81c16f6bf180d9a95b83b5fe50f25e80dL111-R118)

### Submodule Update:
* Updated the `frequenz-api-common` submodule to commit `2e89add6a16d42b23612f0f791a499919f3738ed` to reflect changes in the common protobuf definitions.