### PR TITLE
refactor(api): rename list methods to streaming methods in assets.proto

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,11 +2,8 @@
 
 ## Summary
 
+## Breaking Changes
 
-## Upgrading
-
-- Update the `frequenz-api-common` dependency 
-
-## New Features
+- Changed list methods to streaming methods to align with the rest of the APIs
 
 

--- a/proto/frequenz/api/assets/v1/assets.proto
+++ b/proto/frequenz/api/assets/v1/assets.proto
@@ -25,14 +25,14 @@ service PlatformAssets {
   rpc GetMicrogrid(GetMicrogridRequest) returns (GetMicrogridResponse);
 
   // Returns list of a electrical components for a specific microgrid.
-  rpc ListMicrogridElectricalComponents(ListMicrogridElectricalComponentsRequest)
-    returns (ListMicrogridElectricalComponentsResponse);
+  rpc ReceiveMicrogridElectricalComponentsStream(ReceiveMicrogridElectricalComponentsStreamRequest)
+    returns (stream ReceiveMicrogridElectricalComponentsStreamResponse);
 
   // Returns a list of the connections between electrical components for a
   // specific microgrid.
-  rpc ListMicrogridElectricalComponentConnections(
-    ListMicrogridElectricalComponentConnectionsRequest
-  ) returns (ListMicrogridElectricalComponentConnectionsResponse);
+  rpc ReceiveMicrogridElectricalComponentConnectionsStream(
+    ReceiveMicrogridElectricalComponentConnectionsStreamRequest
+  ) returns (stream ReceiveMicrogridElectricalComponentConnectionsStreamResponse);
 }
 
 // GetMicrogridRequest is the input parameter for fetching details
@@ -49,8 +49,8 @@ message GetMicrogridResponse {
   frequenz.api.common.v1alpha8.microgrid.Microgrid microgrid = 1;
 }
 
-// Request parameters for the RPC `ListMicrogridElectricalComponents`.
-message ListMicrogridElectricalComponentsRequest {
+// Request parameters for the RPC `ReceiveMicrogridElectricalComponentsStream`.
+message ReceiveMicrogridElectricalComponentsStreamRequest {
   // Mandatory field. The ID of the microgrid for which components
   // are to be listed.
   uint64 microgrid_id = 1;
@@ -62,8 +62,8 @@ message ListMicrogridElectricalComponentsRequest {
   repeated frequenz.api.common.v1alpha8.microgrid.electrical_components.ElectricalComponentCategory categories = 3;
 }
 
-// A message containing a list of electrical components.
-message ListMicrogridElectricalComponentsResponse {
+// ReceiveMicrogridElectricalComponentsStreamResponse is a message containing a list of electrical components.
+message ReceiveMicrogridElectricalComponentsStreamResponse {
   // Unique microgrid identifier used in the request.
   uint64 microgrid_id = 1;
   
@@ -71,7 +71,7 @@ message ListMicrogridElectricalComponentsResponse {
   repeated frequenz.api.common.v1alpha8.microgrid.electrical_components.ElectricalComponent components = 2;
 }
 
-// ListMicrogridElectricalComponentConnectionsRequest is used for filtering and listing
+// ReceiveMicrogridElectricalComponentConnectionsStreamRequest is used for filtering and listing
 // the electrical connections between components in a specific microgrid. 
 // These connections can be used to construct a component graph of the
 // microgrid.
@@ -94,7 +94,7 @@ message ListMicrogridElectricalComponentsResponse {
 //     destination_component_id. If these fields are left empty, connections with
 //     any source or destination will be returned.
 //
-message ListMicrogridElectricalComponentConnectionsRequest {
+message ReceiveMicrogridElectricalComponentConnectionsStreamRequest {
   // Mandatory field. The ID of the microgrid
   // for which connections are to be listed.
   uint64 microgrid_id = 1;
@@ -108,10 +108,10 @@ message ListMicrogridElectricalComponentConnectionsRequest {
   repeated uint64 destination_component_ids = 3;
 }
 
-// ListMicrogridElectricalComponentConnectionsResponse holds the list of electrical
+// ReceiveMicrogridElectricalComponentConnectionsStreamResponse holds the list of electrical
 // connections that match the filter criteria specified in the
-// ListMicrogridElectricalComponentConnectionsRequest.
-message ListMicrogridElectricalComponentConnectionsResponse {
+// ReceiveMicrogridElectricalComponentConnectionsStreamRequest.
+message ReceiveMicrogridElectricalComponentConnectionsStreamResponse {
   // The ID of the microgrid for which connections are returned.
   uint64 microgrid_id = 1;
   


### PR DESCRIPTION
Updated the RPC methods in assets.proto to use streaming for electrical components and connections, enhancing consistency with other APIs. Adjusted corresponding request and response message names in the proto file. Updated release notes to reflect these breaking changes.