### PR TITLE
feat(assets): add ListMicrogrids, GetGridpool RPC and associated request/response messages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,5 +12,4 @@ Rename service
 - Introduced new version
 
 ## New Features
-
-n/a
+- Add the `GetGridpool` RPC to the `PlatformAssets` service.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,14 +2,19 @@
 
 ## Summary
 
-Documentation improvement
-Rename service
+This release adds `ListMicrogrids` and `GetGridpool` to
+`frequenz.api.platformassets.v1alpha1`.
 
 ## Upgrading
 
-- Improved ListMicrogridElectricalComponentConnectionsRequest header doc
-- Rename service
-- Introduced new version
+- `frequenz.api.platformassets.v1alpha1.PlatformAssetsService` now includes
+  `ListMicrogrids`.
+- `frequenz.api.platformassets.v1alpha1` includes the `GetGridpool`
+  request/response messages and RPC.
+- `frequenz.api.platformassets.v1alpha1` remains a separate versioned package
+  with the renamed `PlatformAssetsService`.
 
 ## New Features
-- Add the `GetGridpool` RPC to the `PlatformAssets` service.
+
+- Add the `ListMicrogrids` RPC to the `PlatformAssetsService` service.
+- Add the `GetGridpool` RPC to the `PlatformAssetsService` service.

--- a/proto/frequenz/api/assets/v1/assets.proto
+++ b/proto/frequenz/api/assets/v1/assets.proto
@@ -13,7 +13,10 @@ syntax = "proto3";
 package frequenz.api.assets.v1;
 
 // protolint:disable:next MAX_LINE_LENGTH
+import "frequenz/api/common/v1alpha8/gridpool/gridpool.proto";
+// protolint:disable:next MAX_LINE_LENGTH
 import "frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto";
+// protolint:disable:next MAX_LINE_LENGTH
 import "frequenz/api/common/v1alpha8/microgrid/microgrid.proto";
 
 // Service providing access to manage and retrieve information
@@ -25,13 +28,13 @@ service PlatformAssets {
   // Returns list of a electrical components for a specific microgrid.
   rpc ListMicrogridElectricalComponents(
       ListMicrogridElectricalComponentsRequest)
-    returns (ListMicrogridElectricalComponentsResponse);
+      returns (ListMicrogridElectricalComponentsResponse);
 
   // Returns a list of the connections between electrical components for a
   // specific microgrid.
   rpc ListMicrogridElectricalComponentConnections(
-    ListMicrogridElectricalComponentConnectionsRequest)
-  returns (ListMicrogridElectricalComponentConnectionsResponse);
+      ListMicrogridElectricalComponentConnectionsRequest)
+      returns (ListMicrogridElectricalComponentConnectionsResponse);
 }
 
 // GetMicrogridRequest is the input parameter for fetching details
@@ -53,7 +56,7 @@ message ListMicrogridElectricalComponentsRequest {
   // Mandatory field. The ID of the microgrid for which components
   // are to be listed.
   uint64 microgrid_id = 1;
-  
+
   // Return components that have the specified IDs only.
   repeated uint64 component_ids = 2;
 
@@ -66,7 +69,7 @@ message ListMicrogridElectricalComponentsRequest {
 message ListMicrogridElectricalComponentsResponse {
   // Unique microgrid identifier used in the request.
   uint64 microgrid_id = 1;
-  
+
   // List of electrical components matching the filter criteria.
   repeated frequenz.api.common.v1alpha8.microgrid.electrical_components.
       ElectricalComponent components = 2;
@@ -112,8 +115,24 @@ message ListMicrogridElectricalComponentConnectionsRequest {
 message ListMicrogridElectricalComponentConnectionsResponse {
   // The ID of the microgrid for which connections are returned.
   uint64 microgrid_id = 1;
-  
+
   // Contains the list of connections that match the filtering criteria.
   repeated frequenz.api.common.v1alpha8.microgrid.electrical_components.
-      ElectricalComponentConnection connections =2;
+      ElectricalComponentConnection connections = 2;
+}
+
+// GetGridpoolRequest is the input parameter for fetching details
+// given a specific gridpool.
+message GetGridpoolRequest {
+  // The unique identifier of the gridpool for which to fetch details.
+  uint64 gridpool_id = 1;
+}
+
+// GetGridpoolResponse is the response for fetching details
+// given a specific gridpool.
+message GetGridpoolResponse {
+  // Details of the requested gridpool.
+  frequenz.api.common.v1alpha8.gridpool.Gridpool gridpool = 1;
+  // List of microgrids in the gridpool.
+  repeated frequenz.api.common.v1alpha8.microgrid.Microgrid microgrids = 2;
 }

--- a/proto/frequenz/api/assets/v1/assets.proto
+++ b/proto/frequenz/api/assets/v1/assets.proto
@@ -13,10 +13,7 @@ syntax = "proto3";
 package frequenz.api.assets.v1;
 
 // protolint:disable:next MAX_LINE_LENGTH
-import "frequenz/api/common/v1alpha8/gridpool/gridpool.proto";
-// protolint:disable:next MAX_LINE_LENGTH
 import "frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto";
-// protolint:disable:next MAX_LINE_LENGTH
 import "frequenz/api/common/v1alpha8/microgrid/microgrid.proto";
 
 // Service providing access to manage and retrieve information
@@ -28,13 +25,13 @@ service PlatformAssets {
   // Returns list of a electrical components for a specific microgrid.
   rpc ListMicrogridElectricalComponents(
       ListMicrogridElectricalComponentsRequest)
-      returns (ListMicrogridElectricalComponentsResponse);
+    returns (ListMicrogridElectricalComponentsResponse);
 
   // Returns a list of the connections between electrical components for a
   // specific microgrid.
   rpc ListMicrogridElectricalComponentConnections(
-      ListMicrogridElectricalComponentConnectionsRequest)
-      returns (ListMicrogridElectricalComponentConnectionsResponse);
+    ListMicrogridElectricalComponentConnectionsRequest)
+  returns (ListMicrogridElectricalComponentConnectionsResponse);
 }
 
 // GetMicrogridRequest is the input parameter for fetching details
@@ -56,7 +53,7 @@ message ListMicrogridElectricalComponentsRequest {
   // Mandatory field. The ID of the microgrid for which components
   // are to be listed.
   uint64 microgrid_id = 1;
-
+  
   // Return components that have the specified IDs only.
   repeated uint64 component_ids = 2;
 
@@ -69,7 +66,7 @@ message ListMicrogridElectricalComponentsRequest {
 message ListMicrogridElectricalComponentsResponse {
   // Unique microgrid identifier used in the request.
   uint64 microgrid_id = 1;
-
+  
   // List of electrical components matching the filter criteria.
   repeated frequenz.api.common.v1alpha8.microgrid.electrical_components.
       ElectricalComponent components = 2;
@@ -115,24 +112,8 @@ message ListMicrogridElectricalComponentConnectionsRequest {
 message ListMicrogridElectricalComponentConnectionsResponse {
   // The ID of the microgrid for which connections are returned.
   uint64 microgrid_id = 1;
-
+  
   // Contains the list of connections that match the filtering criteria.
   repeated frequenz.api.common.v1alpha8.microgrid.electrical_components.
-      ElectricalComponentConnection connections = 2;
-}
-
-// GetGridpoolRequest is the input parameter for fetching details
-// given a specific gridpool.
-message GetGridpoolRequest {
-  // The unique identifier of the gridpool for which to fetch details.
-  uint64 gridpool_id = 1;
-}
-
-// GetGridpoolResponse is the response for fetching details
-// given a specific gridpool.
-message GetGridpoolResponse {
-  // Details of the requested gridpool.
-  frequenz.api.common.v1alpha8.gridpool.Gridpool gridpool = 1;
-  // List of microgrids in the gridpool.
-  repeated frequenz.api.common.v1alpha8.microgrid.Microgrid microgrids = 2;
+      ElectricalComponentConnection connections =2;
 }

--- a/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
+++ b/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
@@ -13,6 +13,8 @@ syntax = "proto3";
 package frequenz.api.platformassets.v1alpha1;
 
 // protolint:disable:next MAX_LINE_LENGTH
+import "frequenz/api/common/v1alpha8/gridpool/gridpool.proto";
+// protolint:disable:next MAX_LINE_LENGTH
 import "frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto";
 import "frequenz/api/common/v1alpha8/microgrid/microgrid.proto";
 
@@ -36,6 +38,12 @@ import "frequenz/api/common/v1alpha8/microgrid/microgrid.proto";
 //     over TLS (HTTPS).
 //
 service PlatformAssetsService {
+  // Returns metadata for all microgrids visible to the caller.
+  rpc ListMicrogrids(ListMicrogridsRequest) returns (ListMicrogridsResponse);
+
+  // Returns metadata for a specific gridpool.
+  rpc GetGridpool(GetGridpoolRequest) returns (GetGridpoolResponse);
+
   // Returns metadata for a specific microgrid.
   rpc GetMicrogrid(GetMicrogridRequest) returns (GetMicrogridResponse);
 
@@ -49,6 +57,30 @@ service PlatformAssetsService {
   rpc ListMicrogridElectricalComponentConnections(
       ListMicrogridElectricalComponentConnectionsRequest)
       returns (ListMicrogridElectricalComponentConnectionsResponse);
+}
+
+// Request message for listing all visible microgrids.
+message ListMicrogridsRequest {
+}
+
+// Response message containing all visible microgrids.
+message ListMicrogridsResponse {
+  // Microgrids visible to the caller.
+  repeated frequenz.api.common.v1alpha8.microgrid.Microgrid microgrids = 1;
+}
+
+// Request message for retrieving metadata for a specific gridpool.
+message GetGridpoolRequest {
+  // The unique identifier of the gridpool for which to fetch details.
+  uint64 gridpool_id = 1;
+}
+
+// Response message containing metadata for a specific gridpool.
+message GetGridpoolResponse {
+  // Details of the requested gridpool.
+  frequenz.api.common.v1alpha8.gridpool.Gridpool gridpool = 1;
+  // Microgrids belonging to the requested gridpool.
+  repeated frequenz.api.common.v1alpha8.microgrid.Microgrid microgrids = 2;
 }
 
 // Filters for selecting electrical component connections in a microgrid.


### PR DESCRIPTION
This pull request introduces two new RPCs, `ListMicrogrids` and `GetGridpool`, to `PlatformAssetsService` API
, enhancing the ability to retrieve microgrid and gridpool metadata. It also updates the release notes and synchronizes the common API submodule.
