### PR TITLE
Added ListGridpoolEnergySchedules and ListMicrogridSensors RPCs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,16 +2,14 @@
 
 ## Summary
 
-This release introduces energy schedule retrieval and receiving of sensor 
-metadata.
+This release renames `MarketLocationSelector` to `MarketLocation`
 
 ## Upgrading
 
-- Import path changes from Frequenz Common API
+- Rename `MarketLocationSelector` to `MarketLocation`.
 
 ## New Features
 
-- New ListGridpoolEnergySchedules and ListMicrogridSensors RPCs have been added
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,15 +2,16 @@
 
 ## Summary
 
-This release introduces Gridpool assignment discovery to the Platform Assets API.
+This release introduces energy schedule retrieval and receiving of sensor 
+metadata.
 
 ## Upgrading
 
-- Minor documentation changes.
+- Import path changes from Frequenz Common API
 
 ## New Features
 
-- New ListGridpoolAssignments RPC has been added
+- New ListGridpoolEnergySchedules and ListMicrogridSensors RPCs have been added
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
+++ b/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
@@ -49,10 +49,6 @@ import "google/protobuf/timestamp.proto";
 // planned microgrids, including electrical components, sensors, and the
 // directed electrical component graph.
 //
-// Platform asset and market-topology metadata is used by reporting,
-// forecasting, monitoring, trading, optimization, data science, deployment
-// validation, and operational tooling.
-//
 // !!! important "Authentication"
 //     All requests to PlatformAssetsService must be signed. The key identifier
 //     and signature must be included in the request metadata (gRPC metadata /
@@ -120,7 +116,7 @@ enum MarketParticipationType {
 
   // ANCILLARY_SERVICES: The relation participates in ancillary services or
   // flex-market services, such as FCR, aFRR, or other grid-operator services.
-  MARKET_PARTICIPATION_TYPE_ANCILLARY_SERVICES = 2;
+  MARKET_PARTICIPATION_TYPE_FLEX_MARKETS = 2;
 }
 
 // Describes the participation of a market-topology relation in a specific use
@@ -138,13 +134,10 @@ message MarketParticipation {
   // If set, the interval describes when this relation is valid for the given
   // use case. The interval is inclusive at `start_time` and exclusive at
   // `end_time`.
-  frequenz.api.common.v1alpha8.types.Interval validity_period = 2;
-
-  // Optional. Timestamp at which this participation was cancelled.
   //
-  // If set, this participation should no longer be considered effective from
-  // this timestamp onward, even if `validity_period.end_time` is later.
-  optional google.protobuf.Timestamp cancel_time = 3;
+  // Updating `end_time` can be used to end a participation. Updating
+  // `start_time` can be used to move a participation into the future.
+  frequenz.api.common.v1alpha8.types.Interval validity_period = 2;
 }
 
 // Describes a market-topology relation between a Gridpool, Microgrid, and
@@ -189,12 +182,16 @@ message MarketParticipation {
 //
 //     If `gridpool_id` is unset, both `microgrid_id` and
 //     `market_location_selector` must be set. In that case, the relation does
-//     not represent market participation.
-//
-//     If `gridpool_id` is set, `delivery_area` is required.
+//     not represent market participation, but the relation can remain as
+//     a Microgrid-to-Market-Location relation without Gridpool participation.
+//     Gridpool-specific fields, such as `delivery_area` and `participations`,
+//     no longer apply once `gridpool_id` is unset. If `gridpool_id` is set,
+//     `delivery_area` is required.
 //
 //     `participations` are only valid when `gridpool_id` is set.
 //
+//      If removing `gridpool_id` would leave only `microgrid_id` or only
+//     `market_location_selector`, no valid relation remains.
 //
 message MarketTopologyRelation {
   // Optional. The Microgrid associated with this relation.
@@ -214,8 +211,7 @@ message MarketTopologyRelation {
   //
   // If `gridpool_id` is unset, this field links the Market Location to the
   // Microgrid without market participation.
-  frequenz.api.common.v1alpha8.grid.MarketLocationSelector
-      market_location_selector = 2;
+  frequenz.api.common.v1alpha8.grid.MarketLocation market_location = 2;
 
   // Optional. The Gridpool associated with this relation.
   //
@@ -239,7 +235,8 @@ message MarketTopologyRelation {
   // energy trading may start before ancillary services, or ancillary services
   // may end while the Market Location remains associated for energy trading.
   //
-  // Participations are only valid when `gridpool_id` is set.
+  // Participations are only valid when `gridpool_id` is set. If `gridpool_id` is
+  // unset, this field must be empty.
   repeated MarketParticipation participations = 5;
 }
 
@@ -283,18 +280,21 @@ message GridpoolEnergyScheduleTimeSeriesEntry {
 //     the counterparty balancing group.
 //
 // !!! note "Delivery areas"
-//     `gridpool_delivery_area` describes the delivery area of the
-//     Frequenz/Gridpool side of the scheduled exchange.
+//     `frequenz_delivery_area` describes the delivery area of the Frequenz
+//     side of the scheduled exchange.
 //
 //     `counterparty_delivery_area` describes the delivery area of the
-//     counterparty balancing group.
+//     counterparty side of the scheduled exchange.
 //
-//     If both delivery areas are the same, the schedule represents an internal
-//     schedule within one delivery area.
+//     These fields describe the schedule context. They do not imply that the
+//     Gridpool itself is assigned to a single delivery area.
 //
-//     If they differ, the schedule represents an external schedule across
-//     delivery areas and may be subject to additional matching, nomination, and
-//     capacity-right validation.
+//     If both delivery areas are the same, the schedule represents an exchange
+//     within one delivery area.
+//
+//     If they differ, the schedule represents an exchange across delivery areas
+//     and may be subject to additional matching, nomination, and capacity-right
+//     validation.
 //
 // !!! note "Effective validity"
 //     `validity_period` describes the originally configured schedule period.
@@ -305,8 +305,9 @@ message GridpoolEnergyScheduleTimeSeriesEntry {
 //     `validity_period`.
 //
 //     The API does not expose an active/inactive status because such a status
-//     is derived from `validity_period`, `cancel_time`, and the client's
-//     evaluation time.
+//     is time-dependent. Consumers can derive it by comparing the schedule's
+//     effective validity period with the timestamp at which they evaluate the
+//     schedule.
 //
 message GridpoolEnergySchedule {
   // Unique identifier of the Gridpool the energy schedule belongs to.
@@ -324,19 +325,23 @@ message GridpoolEnergySchedule {
 
   // Delivery area of the counterparty side of the scheduled exchange.
   //
-  // If this is the same as `gridpool_delivery_area`, the schedule represents
-  // an internal schedule within one delivery area.
+  // If this is the same as `frequenz_delivery_area`, the schedule represents an
+  // exchange within one delivery area.
   //
-  // If this differs from `gridpool_delivery_area`, the schedule represents an
-  // external schedule across delivery areas and may be subject to additional
-  // matching, nomination, and capacity-right validation.
+  // If this differs from `frequenz_delivery_area`, the schedule represents an
+  // exchange across delivery areas and may be subject to additional matching,
+  // nomination, and capacity-right validation.
   frequenz.api.common.v1alpha8.grid.DeliveryArea counterparty_delivery_area = 5;
 
-  // Delivery area of the Frequenz/Gridpool side of the scheduled exchange.
+  // Delivery area of the Frequenz side of the scheduled exchange.
   //
-  // This is the delivery area in which the Frequenz balancing group
-  // participates for this schedule.
-  frequenz.api.common.v1alpha8.grid.DeliveryArea gridpool_delivery_area = 6;
+  // This is the delivery area in which the Frequenz balancing group participates
+  // for this schedule.
+  //
+  // This field does not imply that the Gridpool itself belongs to only one
+  // delivery area. A Gridpool can have relations or schedules in different
+  // delivery areas.
+  frequenz.api.common.v1alpha8.grid.DeliveryArea frequenz_delivery_area = 6;
 
   // Direction of the scheduled energy exchange from the perspective of the
   // Frequenz balancing group.
@@ -422,13 +427,22 @@ message ListGridpoolEnergySchedulesRequest {
     // If empty, no direction filtering is applied.
     repeated GridpoolEnergyScheduleDirection directions = 2;
 
-    // Optional. Return only schedule entries whose `start_time` falls within
-    // this interval.
-    //
-    // The interval is inclusive at `start_time` and exclusive at `end_time`.
-    //
-    // If omitted, no delivery-time filtering is applied.
-    frequenz.api.common.v1alpha8.types.Interval delivery_time_interval = 3;
+  // Optional. Restrict returned `time_series` entries to delivery periods that
+  // overlap this interval.
+  //
+  // A time-series entry matches if its delivery period overlaps the requested
+  // interval:
+  //
+  // ```text
+  // entry.start_time < time_series_interval.end_time
+  // AND
+  // entry.start_time + schedule.delivery_duration >
+  //     time_series_interval.start_time
+  // ```
+  //
+  // The returned schedules contain only matching `time_series` entries. If
+  // omitted, no time-series filtering is applied.
+  frequenz.api.common.v1alpha8.types.Interval time_series_interval = 3;
 
     // Optional. Return only schedules whose effective validity period overlaps
     // this interval.
@@ -497,11 +511,16 @@ message ListMarketTopologyRelationsRequest {
     // If empty, no Microgrid-ID filtering is applied.
     repeated uint64 microgrid_ids = 2;
 
-    // Optional. Return only relations involving any of these Market Locations.
+    // Optional. Return only relations involving Market Locations whose ID values
+    // match any of these filters.
     //
-    // If empty, no Market Location filtering is applied.
-    repeated frequenz.api.common.v1alpha8.grid.MarketLocationSelector
-        market_location_selectors = 3;
+    // This filter does not require callers to provide the Market Area. It is useful
+    // when the Market Location identifier is known, but the Market Area has not
+    // been resolved yet.
+    //
+    // If empty, no Market Location-ID filtering is applied.
+    repeated frequenz.api.common.v1alpha8.grid.MarketLocationIdValue
+        market_location_id_values = 3;
 
     // Optional. Return only relations applying to any of these delivery areas.
     //
@@ -562,8 +581,9 @@ message ListMicrogridsRequest {
     // If empty, no microgrid-ID filtering is applied.
     repeated uint64 microgrid_ids = 1;
 
-    // Optional. Return only microgrids assigned to any of these Gridpools
-    // within the current enterprise scope.
+    // Optional. Return only microgrids that are part of a market-topology
+    // relation involving any of these Gridpools within the current enterprise
+    // scope.
     //
     // If empty, no Gridpool-ID filtering is applied.
     repeated uint64 gridpool_ids = 2;

--- a/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
+++ b/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
@@ -93,20 +93,6 @@ enum GridpoolEnergyScheduleDirection {
   GRIDPOOL_ENERGY_SCHEDULE_DIRECTION_EXPORT = 2;
 }
 
-// Describes whether a Gridpool energy schedule is active.
-enum GridpoolEnergyScheduleStatus {
-  // UNSPECIFIED: Unspecified energy schedule status.
-  GRIDPOOL_ENERGY_SCHEDULE_STATUS_UNSPECIFIED = 0;
-
-  // ACTIVE: The energy schedule is active and should be considered by trading
-  // and forecasting applications.
-  GRIDPOOL_ENERGY_SCHEDULE_STATUS_ACTIVE = 1;
-
-  // INACTIVE: The energy schedule is inactive and should not be considered by
-  // trading and forecasting applications.
-  GRIDPOOL_ENERGY_SCHEDULE_STATUS_INACTIVE = 2;
-}
-
 // Describes a structural assignment within a Gridpool.
 //
 // A Gridpool assignment represents one row of membership in a virtual
@@ -163,22 +149,56 @@ message GridpoolEnergyScheduleTimeSeriesEntry {
 
 // Describes a static energy schedule associated with a Gridpool.
 //
-// A Gridpool schedule represents a planned energy exchange between the
-// Frequenz balancing group and a third-party balancing group. It is usually
-// based on a static contractual delivery, such as an OTC contract or a
-// baseline PPA.
+// A Gridpool energy schedule represents a planned energy exchange between the
+// Frequenz/Gridpool side and a third-party balancing group. It is usually based
+// on a static contractual delivery, such as an OTC contract or a baseline PPA.
+//
+// The schedule defines the counterparty balancing group, the delivery areas on
+// both sides of the scheduled exchange, the direction of the exchange from the
+// Frequenz balancing-group perspective, the configured validity period, and the
+// scheduled active-power values.
 //
 // !!! note "Static schedules"
-//     Gridpool schedules represent fixed or pre-agreed delivery quantities.
-//     They are accounted for separately from spot-market optimization and do
-//     not describe pay-as-produced or otherwise dynamically changing delivery
-//     positions.
+//     Gridpool energy schedules represent fixed or pre-agreed delivery
+//     quantities. They are accounted for separately from spot-market
+//     optimization and do not describe pay-as-produced or otherwise dynamically
+//     changing delivery positions.
 //
 // !!! note "Direction"
-//     The schedule direction is always expressed from the perspective of the
-//     Frequenz balancing group. `IMPORT` means energy is imported into the
-//     Frequenz balancing group. `EXPORT` means energy is exported from the
-//     Frequenz balancing group.
+//     The schedule direction is expressed from the perspective of the Frequenz
+//     balancing group.
+//
+//     `IMPORT` means energy is imported into the Frequenz balancing group from
+//     the counterparty balancing group.
+//
+//     `EXPORT` means energy is exported from the Frequenz balancing group to
+//     the counterparty balancing group.
+//
+// !!! note "Delivery areas"
+//     `gridpool_delivery_area` describes the delivery area of the
+//     Frequenz/Gridpool side of the scheduled exchange.
+//
+//     `counterparty_delivery_area` describes the delivery area of the
+//     counterparty balancing group.
+//
+//     If both delivery areas are the same, the schedule represents an internal
+//     schedule within one delivery area.
+//
+//     If they differ, the schedule represents an external schedule across
+//     delivery areas and may be subject to additional matching, nomination, and
+//     capacity-right validation.
+//
+// !!! note "Effective validity"
+//     `validity_period` describes the originally configured schedule period.
+//
+//     If `cancel_time` is set, the schedule should only be considered
+//     effective until `cancel_time`, even if `validity_period.end_time` is
+//     later. The original configured end time remains available in
+//     `validity_period`.
+//
+//     The API does not expose an active/inactive status because such a status
+//     is derived from `validity_period`, `cancel_time`, and the client's
+//     evaluation time.
 //
 message GridpoolEnergySchedule {
   // Unique identifier of the Gridpool the energy schedule belongs to.
@@ -194,21 +214,39 @@ message GridpoolEnergySchedule {
   frequenz.api.common.v1alpha8.grid.BalancingGroup
       counterparty_balancing_group = 4;
 
-  // Delivery area in which the scheduled energy exchange applies.
-  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 5;
+  // Delivery area of the counterparty side of the scheduled exchange.
+  //
+  // If this is the same as `gridpool_delivery_area`, the schedule represents
+  // an internal schedule within one delivery area.
+  //
+  // If this differs from `gridpool_delivery_area`, the schedule represents an
+  // external schedule across delivery areas and may be subject to additional
+  // matching, nomination, and capacity-right validation.
+  frequenz.api.common.v1alpha8.grid.DeliveryArea counterparty_delivery_area = 5;
+
+  // Delivery area of the Frequenz/Gridpool side of the scheduled exchange.
+  //
+  // This is the delivery area in which the Frequenz balancing group
+  // participates for this schedule.
+  frequenz.api.common.v1alpha8.grid.DeliveryArea gridpool_delivery_area = 6;
 
   // Direction of the scheduled energy exchange from the perspective of the
   // Frequenz balancing group.
-  GridpoolEnergyScheduleDirection direction = 6;
-
-  // Current status of the energy schedule.
-  GridpoolEnergyScheduleStatus status = 7;
+  GridpoolEnergyScheduleDirection direction = 7;
 
   // Validity interval of the schedule configuration.
   frequenz.api.common.v1alpha8.types.Interval validity_period = 8;
 
+  // Optional. Timestamp at which the schedule was cancelled.
+  //
+  // If set, the schedule should no longer be considered effective from this
+  // timestamp onward and the effective schedule period ends at `cancel_time`.
+  //
+  // The original configured end time remains available in `validity_period`.
+  google.protobuf.Timestamp cancel_time = 9;
+
   // Scheduled active-power values.
-  repeated GridpoolEnergyScheduleTimeSeriesEntry time_series = 9;
+  repeated GridpoolEnergyScheduleTimeSeriesEntry time_series = 10;
 }
 
 // Request message for listing Gridpools within the current enterprise scope.
@@ -282,21 +320,16 @@ message ListGridpoolEnergySchedulesRequest {
     // If empty, no schedule-ID filtering is applied.
     repeated uint64 schedule_ids = 1;
 
-    // Optional. Return only schedule entries whose delivery periods overlap
-    // this interval.
-    //
-    // If omitted, no delivery-period filtering is applied.
-    frequenz.api.common.v1alpha8.types.Interval delivery_period = 2;
-
-    // Optional. Return only energy schedules with one of these statuses.
-    //
-    // If empty, no status filtering is applied.
-    repeated GridpoolEnergyScheduleStatus statuses = 3;
-
     // Optional. Return only schedules with one of these directions.
     //
     // If empty, no direction filtering is applied.
-    repeated GridpoolEnergyScheduleDirection directions = 4;
+    repeated GridpoolEnergyScheduleDirection directions = 2;
+
+    // Optional. Return only schedule entries whose `start_time` falls within this
+    // interval.
+    //
+    // The interval is inclusive at `start_time` and exclusive at `end_time`.
+    frequenz.api.common.v1alpha8.types.Interval delivery_time_interval = 3;
   }
 
   // The unique identifier of the Gridpool whose schedules should be listed.

--- a/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
+++ b/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
@@ -437,7 +437,7 @@ message ListGridpoolEnergySchedulesRequest {
     // entry.start_time < time_series_interval.end_time
     // AND
     // entry.start_time + schedule.delivery_duration >
-    //     time_series_interval.start_time
+    // time_series_interval.start_time
     // ```
     //
     // The returned schedules contain only matching `time_series` entries. If
@@ -447,14 +447,25 @@ message ListGridpoolEnergySchedulesRequest {
     // Optional. Return only schedules whose effective validity period overlaps
     // this interval.
     //
-    // The effective validity period starts at
-    // `validity_period.start_time`.
+    // Use this filter to retrieve all schedules that are applicable at any
+    // point during the requested time window.
+    //
+    // A schedule matches if its effective validity period intersects the
+    // requested interval:
+    //
+    // ```text
+    // effective_start_time < effective_validity_period.end_time
+    // AND
+    // effective_end_time > effective_validity_period.start_time
+    // ```
+    //
+    // The effective validity period starts at `validity_period.start_time`.
     //
     // If `cancel_time` is set before `validity_period.end_time`, the effective
     // validity period ends at `cancel_time`. Otherwise, it ends at
     // `validity_period.end_time`.
     //
-    // If omitted, no validity-period filtering is applied.
+    // If omitted, no effective-validity-period filtering is applied.
     frequenz.api.common.v1alpha8.types.Interval effective_validity_period = 4;
   }
 

--- a/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
+++ b/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
@@ -154,9 +154,10 @@ message MarketParticipation {
 // how official market-facing metering points, technical Microgrids, and
 // Gridpools are connected.
 //
-// A relation can exist without a Gridpool, in which case it links a Microgrid
-// to a Market Location for metering validation, reporting comparison, or local
-// optimization. Such a relation does not imply market participation.
+// A relation can exist without a Gridpool, in which case it links one
+// Microgrid to one Market Location for metering validation, reporting
+// comparison, or local optimization. A Microgrid can have multiple such
+// relations.
 //
 // When `gridpool_id` is set, the relation describes participation in a
 // Gridpool context. In that case, `delivery_area` is required and
@@ -169,6 +170,19 @@ message MarketParticipation {
 // balancing group, or when a Market Location is temporarily excluded due to
 // metering/reporting issues.
 //
+// !!! note "Multiple Market Locations per Microgrid"
+//     A Microgrid can be associated with multiple Market Locations.
+//
+//     This is common in markets where different Market Locations represent
+//     different metering or settlement roles. For example, a Microgrid can have
+//     separate Market Locations for import and export. It can also have
+//     multiple export Market Locations, for example when different feed-in
+//     assets, such as wind and solar generation, are assigned to different
+//     subsidy, settlement, or regulatory regimes.
+//
+//     Each Microgrid-to-Market-Location association is represented as a
+//     separate MarketTopologyRelation.
+//
 // !!! important "Validation"
 //     A relation must contain at least two of `gridpool_id`, `microgrid_id`,
 //     and `market_location_selector`.
@@ -180,6 +194,7 @@ message MarketParticipation {
 //     If `gridpool_id` is set, `delivery_area` is required.
 //
 //     `participations` are only valid when `gridpool_id` is set.
+//
 //
 message MarketTopologyRelation {
   // Optional. The Microgrid associated with this relation.

--- a/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
+++ b/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
@@ -178,10 +178,10 @@ message MarketParticipation {
 //
 // !!! important "Validation"
 //     A relation must contain at least two of `gridpool_id`, `microgrid_id`,
-//     and `market_location_selector`.
+//     and `market_location`.
 //
 //     If `gridpool_id` is unset, both `microgrid_id` and
-//     `market_location_selector` must be set. In that case, the relation does
+//     `market_location` must be set. In that case, the relation does
 //     not represent market participation, but the relation can remain as
 //     a Microgrid-to-Market-Location relation without Gridpool participation.
 //     Gridpool-specific fields, such as `delivery_area` and `participations`,
@@ -191,7 +191,7 @@ message MarketParticipation {
 //     `participations` are only valid when `gridpool_id` is set.
 //
 //      If removing `gridpool_id` would leave only `microgrid_id` or only
-//     `market_location_selector`, no valid relation remains.
+//     `market_location`, no valid relation remains.
 //
 message MarketTopologyRelation {
   // Optional. The Microgrid associated with this relation.
@@ -235,8 +235,8 @@ message MarketTopologyRelation {
   // energy trading may start before ancillary services, or ancillary services
   // may end while the Market Location remains associated for energy trading.
   //
-  // Participations are only valid when `gridpool_id` is set. If `gridpool_id` is
-  // unset, this field must be empty.
+  // Participations are only valid when `gridpool_id` is set. If `gridpool_id`
+  // is unset, this field must be empty.
   repeated MarketParticipation participations = 5;
 }
 
@@ -335,8 +335,8 @@ message GridpoolEnergySchedule {
 
   // Delivery area of the Frequenz side of the scheduled exchange.
   //
-  // This is the delivery area in which the Frequenz balancing group participates
-  // for this schedule.
+  // This is the delivery area in which the Frequenz balancing group
+  // participates for this schedule.
   //
   // This field does not imply that the Gridpool itself belongs to only one
   // delivery area. A Gridpool can have relations or schedules in different
@@ -427,22 +427,22 @@ message ListGridpoolEnergySchedulesRequest {
     // If empty, no direction filtering is applied.
     repeated GridpoolEnergyScheduleDirection directions = 2;
 
-  // Optional. Restrict returned `time_series` entries to delivery periods that
-  // overlap this interval.
-  //
-  // A time-series entry matches if its delivery period overlaps the requested
-  // interval:
-  //
-  // ```text
-  // entry.start_time < time_series_interval.end_time
-  // AND
-  // entry.start_time + schedule.delivery_duration >
-  //     time_series_interval.start_time
-  // ```
-  //
-  // The returned schedules contain only matching `time_series` entries. If
-  // omitted, no time-series filtering is applied.
-  frequenz.api.common.v1alpha8.types.Interval time_series_interval = 3;
+    // Optional. Restrict returned `time_series` entries to delivery periods
+    // that overlap this interval.
+    //
+    // A time-series entry matches if its delivery period overlaps the requested
+    // interval:
+    //
+    // ```text
+    // entry.start_time < time_series_interval.end_time
+    // AND
+    // entry.start_time + schedule.delivery_duration >
+    //     time_series_interval.start_time
+    // ```
+    //
+    // The returned schedules contain only matching `time_series` entries. If
+    // omitted, no time-series filtering is applied.
+    frequenz.api.common.v1alpha8.types.Interval time_series_interval = 3;
 
     // Optional. Return only schedules whose effective validity period overlaps
     // this interval.
@@ -511,12 +511,12 @@ message ListMarketTopologyRelationsRequest {
     // If empty, no Microgrid-ID filtering is applied.
     repeated uint64 microgrid_ids = 2;
 
-    // Optional. Return only relations involving Market Locations whose ID values
-    // match any of these filters.
+    // Optional. Return only relations involving Market Locations whose ID
+    // values match any of these filters.
     //
-    // This filter does not require callers to provide the Market Area. It is useful
-    // when the Market Location identifier is known, but the Market Area has not
-    // been resolved yet.
+    // This filter does not require callers to provide the Market Area. It is
+    // useful when the Market Location identifier is known, but the Market
+    // Area has not been resolved yet.
     //
     // If empty, no Market Location-ID filtering is applied.
     repeated frequenz.api.common.v1alpha8.grid.MarketLocationIdValue

--- a/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
+++ b/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
@@ -14,6 +14,7 @@ package frequenz.api.platformassets.v1alpha1;
 
 import "frequenz/api/common/v1alpha8/grid/balancing_group.proto";
 import "frequenz/api/common/v1alpha8/grid/delivery_area.proto";
+import "frequenz/api/common/v1alpha8/grid/delivery_duration.proto";
 import "frequenz/api/common/v1alpha8/grid/market_location.proto";
 import "frequenz/api/common/v1alpha8/gridpool/gridpool.proto";
 // protolint:disable:next MAX_LINE_LENGTH

--- a/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
+++ b/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
@@ -297,8 +297,14 @@ message GridpoolEnergySchedule {
   // The original configured end time remains available in `validity_period`.
   google.protobuf.Timestamp cancel_time = 9;
 
+  // Delivery duration used by all time-series entries in this schedule.
+  //
+  // Each `time_series` entry applies from `entry.start_time` until
+  // `entry.start_time + delivery_duration`.
+  frequenz.api.common.v1alpha8.grid.DeliveryDuration delivery_duration = 10;
+
   // Scheduled active-power values.
-  repeated GridpoolEnergyScheduleTimeSeriesEntry time_series = 10;
+  repeated GridpoolEnergyScheduleTimeSeriesEntry time_series = 11;
 }
 
 // Request message for listing Gridpools within the current enterprise scope.
@@ -381,7 +387,22 @@ message ListGridpoolEnergySchedulesRequest {
     // this interval.
     //
     // The interval is inclusive at `start_time` and exclusive at `end_time`.
+    //
+    // If omitted, no delivery-time filtering is applied.
     frequenz.api.common.v1alpha8.types.Interval delivery_time_interval = 3;
+
+    // Optional. Return only schedules whose effective validity period overlaps
+    // this interval.
+    //
+    // The effective validity period starts at
+    // `validity_period.start_time`.
+    //
+    // If `cancel_time` is set before `validity_period.end_time`, the effective
+    // validity period ends at `cancel_time`. Otherwise, it ends at
+    // `validity_period.end_time`.
+    //
+    // If omitted, no validity-period filtering is applied.
+    frequenz.api.common.v1alpha8.types.Interval effective_validity_period = 4;
   }
 
   // The unique identifier of the Gridpool whose schedules should be listed.

--- a/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
+++ b/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
@@ -25,17 +25,33 @@ import "frequenz/api/common/v1alpha8/types/interval.proto";
 
 import "google/protobuf/timestamp.proto";
 
-// PlatformAssetsService provides read-only access to platform asset metadata.
+// PlatformAssetsService provides read-only access to platform asset and
+// market-topology metadata.
 //
-// The service exposes technical asset information required by downstream
-// services and applications, including microgrid metadata, electrical
-// component inventories, and the directed electrical component graph within a
-// microgrid.
+// The service exposes a platform-wide read model for resolving stable
+// identifiers, asset inventories, and relationships managed by the Frequenz
+// platform. This includes Gridpools, microgrids, Market Locations,
+// market-topology relations, Gridpool energy schedules, electrical component
+// inventories, sensor inventories, and the directed electrical component graph
+// within a microgrid.
 //
-// Platform assets describe the technical structure of a deployed or planned
-// microgrid. They are commonly used by reporting, forecasting, monitoring,
-// trading, optimization, and operational tooling to resolve stable asset
-// identifiers into their associated metadata.
+// Gridpools represent virtual balancing-group structures used for market
+// interactions, such as electricity trading, scheduled energy exchange, and
+// flexibility or ancillary-service participation.
+//
+// Market-topology relations describe how Gridpools, Microgrids, and Market
+// Locations are connected. These relations define which market-facing metering
+// points and technical Microgrids participate in a Gridpool context, and can
+// also describe Microgrid-to-Market-Location relations that exist without
+// market participation.
+//
+// Microgrid asset metadata describes the technical structure of deployed or
+// planned microgrids, including electrical components, sensors, and the
+// directed electrical component graph.
+//
+// Platform asset and market-topology metadata is used by reporting,
+// forecasting, monitoring, trading, optimization, data science, deployment
+// validation, and operational tooling.
 //
 // !!! important "Authentication"
 //     All requests to PlatformAssetsService must be signed. The key identifier
@@ -48,14 +64,13 @@ service PlatformAssetsService {
   // Lists Gridpools within the current enterprise scope.
   rpc ListGridpools(ListGridpoolsRequest) returns (ListGridpoolsResponse);
 
-  // Lists market locations and/or microgrids that are assigned to a
-  // specific Gridpool.
-  rpc ListGridpoolAssignments(ListGridpoolAssignmentsRequest)
-      returns (ListGridpoolAssignmentsResponse);
-
   // Lists energy schedules for a specific Gridpool.
   rpc ListGridpoolEnergySchedules(ListGridpoolEnergySchedulesRequest)
       returns (ListGridpoolEnergySchedulesResponse);
+
+  // Lists market-topology relations within the current enterprise scope.
+  rpc ListMarketTopologyRelations(ListMarketTopologyRelationsRequest)
+      returns (ListMarketTopologyRelationsResponse);
 
   // Returns metadata for a specific microgrid.
   rpc GetMicrogrid(GetMicrogridRequest) returns (GetMicrogridResponse);
@@ -94,87 +109,33 @@ enum GridpoolEnergyScheduleDirection {
   GRIDPOOL_ENERGY_SCHEDULE_DIRECTION_EXPORT = 2;
 }
 
-// Describes a use case for which a Gridpool assignment can participate.
-enum GridpoolAssignmentParticipationType {
-  // Unspecified participation type.
-  GRIDPOOL_ASSIGNMENT_PARTICIPATION_TYPE_UNSPECIFIED = 0;
+// Describes a market-related use case for which a relation can participate.
+enum MarketParticipationType {
+  // UNSPECIFIED: Unspecified participation type.
+  MARKET_PARTICIPATION_TYPE_UNSPECIFIED = 0;
 
-  // ENERGY_TRADING: The assignment participates in energy trading, supply,
+  // ENERGY_TRADING: The relation participates in energy trading, supply,
   // balancing, or settlement of scheduled and measured energy.
-  GRIDPOOL_ASSIGNMENT_PARTICIPATION_TYPE_ENERGY_TRADING = 1;
+  MARKET_PARTICIPATION_TYPE_ENERGY_TRADING = 1;
 
-  // ANCILLARY_SERVICES: The assignment participates in ancillary services or
+  // ANCILLARY_SERVICES: The relation participates in ancillary services or
   // flex-market services, such as FCR, aFRR, or other grid-operator services.
-  GRIDPOOL_ASSIGNMENT_PARTICIPATION_TYPE_ANCILLARY_SERVICES = 2;
+  MARKET_PARTICIPATION_TYPE_ANCILLARY_SERVICES = 2;
 }
 
-// Describes a structural assignment within a Gridpool.
-//
-// A Gridpool assignment represents one row of membership in a virtual
-// balancing group. It can reference a Market Location, a Microgrid, or both.
-//
-// A Market Location is the commercial/regulatory metering point used for
-// settlement, balancing-group allocation, forecasting, and measured energy
-// flows. A Microgrid is the technical/control representation of a site or
-// energy system.
-//
-// Market Locations and Microgrids can exist independently. Therefore, neither
-// resource owns the relationship. The assignment is the association record.
-//
-// !!! important "Validation"
-//     At least one of `market_location_selector` or `microgrid_id` must be set.
-//     Both fields may be set when the Market Location and Microgrid are linked
-//     in this Gridpool context.
-//
-message GridpoolAssignment {
-  // Optional. The Market Location associated with this assignment.
-  //
-  // The Market Location is the official metering point that describes measured
-  // energy flows into or out of the virtual balancing group.
-  //
-  // This field can be set without `microgrid_id` if the Market Location is
-  // assigned to the Gridpool before a Microgrid deployment exists.
-  frequenz.api.common.v1alpha8.grid.MarketLocationSelector
-      market_location_selector = 1;
-
-  // Optional. The Microgrid associated with this assignment.
-  //
-  // The Microgrid is the technical/control representation of a site or energy
-  // system.
-  //
-  // This field can be set without `market_location_selector` if the Microgrid
-  // is assigned to the Gridpool independently of a directly managed Market
-  // Location.
-  optional uint64 microgrid_id = 2;
-
-  // Delivery area in which this assignment applies.
-  //
-  // The delivery area is defined in the Gridpool context because it describes
-  // where the assigned Market Location and/or Microgrid participates in the
-  // virtual balancing group.
-  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 3;
-
-  // Use-case-specific participation periods for this assignment.
-  //
-  // Different use cases can become active at different times. For example,
-  // energy trading may start before ancillary services, or ancillary services
-  // may end while the Market Location remains assigned for energy trading.
-  repeated GridpoolAssignmentParticipation participations = 4;
-}
-
-// Describes the validity period of a Gridpool assignment for a specific use
+// Describes the participation of a market-topology relation in a specific use
 // case.
-message GridpoolAssignmentParticipation {
-  // The use case for which this assignment participates.
-  GridpoolAssignmentParticipationType type = 1;
+message MarketParticipation {
+  // The use case for which this relation participates.
+  MarketParticipationType type = 1;
 
   // Optional. Configured validity interval for this participation.
   //
-  // If omitted, no explicit start or end date has been configured for this use
-  // case. Clients must not assume that the participation is inactive only
-  // because this field is unset.
+  // If omitted, the participation has no explicit validity interval in the
+  // returned data. The interpretation of an omitted interval is service-defined
+  // and may depend on the participation type and backend configuration.
   //
-  // If set, the interval describes when this assignment is valid for the given
+  // If set, the interval describes when this relation is valid for the given
   // use case. The interval is inclusive at `start_time` and exclusive at
   // `end_time`.
   frequenz.api.common.v1alpha8.types.Interval validity_period = 2;
@@ -186,18 +147,97 @@ message GridpoolAssignmentParticipation {
   optional google.protobuf.Timestamp cancel_time = 3;
 }
 
+// Describes a market-topology relation between a Gridpool, Microgrid, and
+// Market Location.
+//
+// A MarketTopologyRelation is the canonical relationship record that describes
+// how official market-facing metering points, technical Microgrids, and
+// Gridpools are connected.
+//
+// A relation can exist without a Gridpool, in which case it links a Microgrid
+// to a Market Location for metering validation, reporting comparison, or local
+// optimization. Such a relation does not imply market participation.
+//
+// When `gridpool_id` is set, the relation describes participation in a
+// Gridpool context. In that case, `delivery_area` is required and
+// use-case-specific participations can describe energy trading, ancillary
+// services, or other market-related use cases.
+//
+// A Microgrid-only Gridpool relation is a special case. It is typically used
+// when the Microgrid participates technically while the matching Market
+// Location is represented outside Frequenz, for example through a third-party
+// balancing group, or when a Market Location is temporarily excluded due to
+// metering/reporting issues.
+//
+// !!! important "Validation"
+//     A relation must contain at least two of `gridpool_id`, `microgrid_id`,
+//     and `market_location_selector`.
+//
+//     If `gridpool_id` is unset, both `microgrid_id` and
+//     `market_location_selector` must be set. In that case, the relation does
+//     not represent market participation.
+//
+//     If `gridpool_id` is set, `delivery_area` is required.
+//
+//     `participations` are only valid when `gridpool_id` is set.
+//
+message MarketTopologyRelation {
+  // Optional. The Microgrid associated with this relation.
+  //
+  // If `gridpool_id` is set, the Microgrid participates in the Gridpool
+  // context.
+  //
+  // If `gridpool_id` is unset, this field links the Microgrid to the Market
+  // Location for metering validation, reporting comparison, or local
+  // optimization.
+  optional uint64 microgrid_id = 1;
+
+  // Optional. The Market Location associated with this relation.
+  //
+  // If `gridpool_id` is set, the Market Location participates in the Gridpool
+  // context.
+  //
+  // If `gridpool_id` is unset, this field links the Market Location to the
+  // Microgrid without market participation.
+  frequenz.api.common.v1alpha8.grid.MarketLocationSelector
+      market_location_selector = 2;
+
+  // Optional. The Gridpool associated with this relation.
+  //
+  // If set, this relation describes participation in a virtual balancing group.
+  //
+  // If unset, this relation describes only a Microgrid-to-Market-Location
+  // relationship without Gridpool participation.
+  optional uint64 gridpool_id = 3;
+
+  // Optional. Delivery area in which this relation applies.
+  //
+  // This field is required when `gridpool_id` is set, because the delivery area
+  // only has meaning in the Gridpool/balancing-group context.
+  //
+  // This field must be unset when `gridpool_id` is unset.
+  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 4;
+
+  // Use-case-specific participations for this relation.
+  //
+  // Different use cases can become active at different times. For example,
+  // energy trading may start before ancillary services, or ancillary services
+  // may end while the Market Location remains associated for energy trading.
+  //
+  // Participations are only valid when `gridpool_id` is set.
+  repeated MarketParticipation participations = 5;
+}
+
 // A scheduled active-power value for one delivery period.
 message GridpoolEnergyScheduleTimeSeriesEntry {
   // Start timestamp of the scheduled delivery value.
   //
-  // This timestamp is inclusive.
-  //
-  // The schedule source data contains start timestamps only. The duration of
-  // the delivery value is therefore not represented explicitly by this message.
+  // This timestamp is inclusive. The entry applies until
+  // `start_time + GridpoolEnergySchedule.delivery_duration`.
   google.protobuf.Timestamp start_time = 1;
 
   // Scheduled active power in watts.
-  double active_power_w = 3;
+  double active_power_w = 2;
 }
 
 // Describes a static energy schedule associated with a Gridpool.
@@ -342,23 +382,6 @@ message ListGridpoolsResponse {
   repeated frequenz.api.common.v1alpha8.gridpool.Gridpool gridpools = 1;
 }
 
-// Request message for listing Gridpool assignments within the current
-// enterprise scope.
-message ListGridpoolAssignmentsRequest {
-  // The unique identifier of the Gridpool for which to fetch assignments.
-  uint64 gridpool_id = 1;
-}
-
-// Response message containing Gridpool assignments.
-message ListGridpoolAssignmentsResponse {
-  // The unique identifier of the Gridpool this assignment belongs to.
-  uint64 gridpool_id = 1;
-
-  // Gridpool assignments matching the request filters within the current
-  // enterprise scope.
-  repeated GridpoolAssignment assignments = 2;
-}
-
 // Request message for listing schedules for a specific Gridpool.
 message ListGridpoolEnergySchedulesRequest {
   // Filters for selecting Gridpool schedules.
@@ -421,6 +444,7 @@ message ListGridpoolEnergySchedulesRequest {
 // The response contains schedules for the requested Gridpool matching the
 // requested filters within the current enterprise scope. If no matching
 // schedules are available in that scope, `schedules` is empty.
+//
 message ListGridpoolEnergySchedulesResponse {
   // The unique identifier of the Gridpool the returned schedules belong to.
   uint64 gridpool_id = 1;
@@ -428,6 +452,66 @@ message ListGridpoolEnergySchedulesResponse {
   // Schedules matching the request filters within the current enterprise
   // scope.
   repeated GridpoolEnergySchedule schedules = 2;
+}
+
+// Request message for listing market-topology relations within the current
+// enterprise scope.
+message ListMarketTopologyRelationsRequest {
+  // Filters for selecting market-topology relations.
+  //
+  // A relation must match all specified filter fields to be included in the
+  // response. The current enterprise scope is always applied in addition to
+  // these filters.
+  //
+  // !!! note "Filter Semantics"
+  //     Each repeated field is evaluated using logical OR.
+  //
+  //     Different filter fields are combined using logical AND.
+  //
+  //     If no filters are provided, all market-topology relations within the
+  //     current enterprise scope are returned.
+  //
+  message MarketTopologyRelationsFilter {
+    // Optional. Return only relations involving any of these Gridpools.
+    //
+    // If empty, no Gridpool-ID filtering is applied.
+    repeated uint64 gridpool_ids = 1;
+
+    // Optional. Return only relations involving any of these Microgrids.
+    //
+    // If empty, no Microgrid-ID filtering is applied.
+    repeated uint64 microgrid_ids = 2;
+
+    // Optional. Return only relations involving any of these Market Locations.
+    //
+    // If empty, no Market Location filtering is applied.
+    repeated frequenz.api.common.v1alpha8.grid.MarketLocationSelector
+        market_location_selectors = 3;
+
+    // Optional. Return only relations applying to any of these delivery areas.
+    //
+    // If empty, no delivery-area filtering is applied.
+    repeated frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_areas = 4;
+
+    // Optional. Return only relations that include at least one participation
+    // with one of these types.
+    //
+    // If empty, no participation-type filtering is applied.
+    repeated MarketParticipationType participation_types = 5;
+  }
+
+  // Optional. Filtering criteria for narrowing the returned relations.
+  //
+  // If omitted, all market-topology relations within the current enterprise
+  // scope are returned.
+  MarketTopologyRelationsFilter filter = 1;
+}
+
+// Response message containing market-topology relations.
+message ListMarketTopologyRelationsResponse {
+  // Market-topology relations matching the request filters within the current
+  // enterprise scope.
+  repeated MarketTopologyRelation relations = 1;
 }
 
 // Request message for retrieving metadata for a specific microgrid.
@@ -472,8 +556,8 @@ message ListMicrogridsRequest {
 
   // Optional. Filtering criteria for narrowing the returned microgrids.
   //
-  // If omitted, all microgrids accessible through the authenticated client's
-  // enterprise-scoped authorization context are returned.
+  // If omitted, all microgrids within the current enterprise scope are
+  // returned.
   MicrogridsFilter filter = 1;
 }
 

--- a/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
+++ b/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
@@ -12,11 +12,17 @@ syntax = "proto3";
 
 package frequenz.api.platformassets.v1alpha1;
 
+import "frequenz/api/common/v1alpha8/grid/balancing_group.proto";
+import "frequenz/api/common/v1alpha8/grid/delivery_area.proto";
+import "frequenz/api/common/v1alpha8/grid/market_location.proto";
 import "frequenz/api/common/v1alpha8/gridpool/gridpool.proto";
-import "frequenz/api/common/v1alpha8/market/market_location.proto";
 // protolint:disable:next MAX_LINE_LENGTH
 import "frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto";
 import "frequenz/api/common/v1alpha8/microgrid/microgrid.proto";
+import "frequenz/api/common/v1alpha8/microgrid/sensors/sensors.proto";
+import "frequenz/api/common/v1alpha8/types/interval.proto";
+
+import "google/protobuf/timestamp.proto";
 
 // PlatformAssetsService provides read-only access to platform asset metadata.
 //
@@ -46,6 +52,10 @@ service PlatformAssetsService {
   rpc ListGridpoolAssignments(ListGridpoolAssignmentsRequest)
       returns (ListGridpoolAssignmentsResponse);
 
+  // Lists energy schedules for a specific Gridpool.
+  rpc ListGridpoolEnergySchedules(ListGridpoolEnergySchedulesRequest)
+      returns (ListGridpoolEnergySchedulesResponse);
+
   // Returns metadata for a specific microgrid.
   rpc GetMicrogrid(GetMicrogridRequest) returns (GetMicrogridResponse);
 
@@ -62,6 +72,39 @@ service PlatformAssetsService {
   rpc ListMicrogridElectricalComponentConnections(
       ListMicrogridElectricalComponentConnectionsRequest)
       returns (ListMicrogridElectricalComponentConnectionsResponse);
+
+  // Lists sensors for a specific microgrid.
+  rpc ListMicrogridSensors(ListMicrogridSensorsRequest)
+      returns (ListMicrogridSensorsResponse);
+}
+
+// Describes the direction of a scheduled energy exchange from the perspective
+// of the Frequenz balancing group.
+enum GridpoolEnergyScheduleDirection {
+  // UNSPECIFIED: Unspecified energy schedule direction.
+  GRIDPOOL_ENERGY_SCHEDULE_DIRECTION_UNSPECIFIED = 0;
+
+  // IMPORT: Energy is imported into the Frequenz balancing group from a
+  // third-party balancing group.
+  GRIDPOOL_ENERGY_SCHEDULE_DIRECTION_IMPORT = 1;
+
+  // EXPORT: Energy is exported from the Frequenz balancing group to a
+  // third-party balancing group.
+  GRIDPOOL_ENERGY_SCHEDULE_DIRECTION_EXPORT = 2;
+}
+
+// Describes whether a Gridpool energy schedule is active.
+enum GridpoolEnergyScheduleStatus {
+  // UNSPECIFIED: Unspecified energy schedule status.
+  GRIDPOOL_ENERGY_SCHEDULE_STATUS_UNSPECIFIED = 0;
+
+  // ACTIVE: The energy schedule is active and should be considered by trading
+  // and forecasting applications.
+  GRIDPOOL_ENERGY_SCHEDULE_STATUS_ACTIVE = 1;
+
+  // INACTIVE: The energy schedule is inactive and should not be considered by
+  // trading and forecasting applications.
+  GRIDPOOL_ENERGY_SCHEDULE_STATUS_INACTIVE = 2;
 }
 
 // Describes a structural assignment within a Gridpool.
@@ -90,7 +133,7 @@ message GridpoolAssignment {
   //
   // This field can be set without `microgrid_id` if the Market Location is
   // assigned to the Gridpool before a Microgrid deployment exists.
-  frequenz.api.common.v1alpha8.market.MarketLocationSelector
+  frequenz.api.common.v1alpha8.grid.MarketLocationSelector
       market_location_selector = 1;
 
   // Optional. The Microgrid associated with this assignment.
@@ -102,6 +145,69 @@ message GridpoolAssignment {
   // is assigned to the Gridpool independently of a directly managed Market
   // Location.
   optional uint64 microgrid_id = 2;
+}
+
+// A scheduled active-power value for one delivery period.
+message GridpoolEnergyScheduleTimeSeriesEntry {
+  // Start timestamp of the scheduled delivery value.
+  //
+  // This timestamp is inclusive.
+  //
+  // The schedule source data contains start timestamps only. The duration of
+  // the delivery value is therefore not represented explicitly by this message.
+  google.protobuf.Timestamp start_time = 1;
+
+  // Scheduled active power in watts.
+  double active_power_w = 3;
+}
+
+// Describes a static energy schedule associated with a Gridpool.
+//
+// A Gridpool schedule represents a planned energy exchange between the
+// Frequenz balancing group and a third-party balancing group. It is usually
+// based on a static contractual delivery, such as an OTC contract or a
+// baseline PPA.
+//
+// !!! note "Static schedules"
+//     Gridpool schedules represent fixed or pre-agreed delivery quantities.
+//     They are accounted for separately from spot-market optimization and do
+//     not describe pay-as-produced or otherwise dynamically changing delivery
+//     positions.
+//
+// !!! note "Direction"
+//     The schedule direction is always expressed from the perspective of the
+//     Frequenz balancing group. `IMPORT` means energy is imported into the
+//     Frequenz balancing group. `EXPORT` means energy is exported from the
+//     Frequenz balancing group.
+//
+message GridpoolEnergySchedule {
+  // Unique identifier of the Gridpool the energy schedule belongs to.
+  uint64 gridpool_id = 1;
+
+  // Unique identifier of the energy schedule.
+  uint64 schedule_id = 2;
+
+  // Human-readable name of the energy schedule.
+  string name = 3;
+
+  // The third-party balancing group involved in the scheduled energy exchange.
+  BalancingGroup counterparty_balancing_group = 4;
+
+  // Delivery area in which the scheduled energy exchange applies.
+  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 5;
+
+  // Direction of the scheduled energy exchange from the perspective of the
+  // Frequenz balancing group.
+  GridpoolEnergyScheduleDirection direction = 6;
+
+  // Current status of the energy schedule.
+  GridpoolEnergyScheduleStatus status = 7;
+
+  // Validity interval of the schedule configuration.
+  frequenz.api.common.v1alpha8.types.Interval validity_period = 8;
+
+  // Scheduled active-power values.
+  repeated GridpoolEnergyScheduleTimeSeriesEntry time_series = 9;
 }
 
 // Request message for listing Gridpools within the current enterprise scope.
@@ -153,6 +259,67 @@ message ListGridpoolAssignmentsResponse {
   // Gridpool assignments matching the request filters within the current
   // enterprise scope.
   repeated GridpoolAssignment assignments = 2;
+}
+
+// Request message for listing schedules for a specific Gridpool.
+message ListGridpoolEnergySchedulesRequest {
+  // Filters for selecting Gridpool schedules.
+  //
+  // A schedule must match all specified filter fields to be included in the
+  // response. The current enterprise scope is always applied in addition to
+  // these filters.
+  //
+  // !!! note "Filter Semantics"
+  //     Each repeated field is evaluated using logical OR. Different filter
+  //     fields are combined using logical AND. If no filters are provided,
+  //     all schedules for the requested Gridpool within the current
+  //     enterprise scope are returned.
+  //
+  message GridpoolEnergySchedulesFilter {
+    // Optional. Return only schedules whose IDs are included in this list.
+    //
+    // If empty, no schedule-ID filtering is applied.
+    repeated uint64 schedule_ids = 1;
+
+    // Optional. Return only schedule entries whose delivery periods overlap
+    // this interval.
+    //
+    // If omitted, no delivery-period filtering is applied.
+    frequenz.api.common.v1alpha8.types.Interval delivery_period = 2;
+
+    // Optional. Return only energy schedules with one of these statuses.
+    //
+    // If empty, no status filtering is applied.
+    repeated GridpoolEnergyScheduleStatus statuses = 3;
+
+    // Optional. Return only schedules with one of these directions.
+    //
+    // If empty, no direction filtering is applied.
+    repeated GridpoolEnergyScheduleDirection directions = 4;
+  }
+
+  // The unique identifier of the Gridpool whose schedules should be listed.
+  uint64 gridpool_id = 1;
+
+  // Optional. Filtering criteria for narrowing the returned schedules.
+  //
+  // If omitted, all schedules for the requested Gridpool within the current
+  // enterprise scope are returned.
+  GridpoolEnergySchedulesFilter filter = 2;
+}
+
+// Response message containing Gridpool schedules.
+//
+// The response contains schedules for the requested Gridpool matching the
+// requested filters within the current enterprise scope. If no matching
+// schedules are available in that scope, `schedules` is empty.
+message ListGridpoolEnergySchedulesResponse {
+  // The unique identifier of the Gridpool the returned schedules belong to.
+  uint64 gridpool_id = 1;
+
+  // Schedules matching the request filters within the current enterprise
+  // scope.
+  repeated GridpoolEnergySchedule schedules = 2;
 }
 
 // Request message for retrieving metadata for a specific microgrid.
@@ -222,12 +389,9 @@ message ListMicrogridElectricalComponentsRequest {
   // included in the response.
   //
   // !!! note "Filter Semantics"
-  //     Each repeated field is evaluated using logical OR.
-  //
-  //     Different filter fields are combined using logical AND.
-  //
-  //     If no filters are provided, all electrical components in the microgrid
-  //     are returned.
+  //     Each repeated field is evaluated using logical OR. Different filter
+  //     fields are combined using logical AND. If no filters are provided,
+  //     all electrical components in the microgrid are returned.
   //
   message MicrogridElectricalComponentsFilter {
     // Optional. Return only components whose IDs are included in this list.
@@ -288,12 +452,9 @@ message ListMicrogridElectricalComponentConnectionsRequest {
   // response.
   //
   // !!! note "Filter Semantics"
-  //     Each repeated field is evaluated using logical OR.
-  //
-  //     Different filter fields are combined using logical AND.
-  //
-  //     If no filters are provided, all known electrical connections in the
-  //     microgrid are returned.
+  //     Each repeated field is evaluated using logical OR. Different filter
+  //     fields are combined using logical AND. If no filters are provided,
+  //     all known electrical connections in the microgrid are returned.
   //
   message MicrogridElectricalComponentConnectionsFilter {
     // Optional. Return only connections whose source component ID is
@@ -331,4 +492,39 @@ message ListMicrogridElectricalComponentConnectionsResponse {
   // Electrical component connections matching the request filters.
   repeated frequenz.api.common.v1alpha8.microgrid.electrical_components.
       ElectricalComponentConnection connections = 2;
+}
+
+// Request message for listing sensors in a microgrid.
+message ListMicrogridSensorsRequest {
+  // Filters for selecting sensors in a microgrid.
+  //
+  // A sensor must match all specified filter fields to be included in the
+  // response.
+  //
+  // !!! note "Filter Semantics"
+  //     Each repeated field is evaluated using logical OR. Different filter
+  //     fields are combined using logical AND. If no filters are provided,
+  //     all sensors in the microgrid are returned.
+  //
+  message MicrogridSensorsFilter {
+    // Optional. Return only sensors whose IDs are included in this list.
+    repeated uint64 sensor_ids = 1;
+  }
+
+  // The unique identifier of the microgrid whose sensors should be listed.
+  uint64 microgrid_id = 1;
+
+  // Optional. Filtering criteria for narrowing the returned sensors.
+  //
+  // If omitted, all sensors in the microgrid are returned.
+  MicrogridSensorsFilter filter = 2;
+}
+
+// Response message containing sensors for a microgrid.
+message ListMicrogridSensorsResponse {
+  // The unique identifier of the microgrid the returned sensors belong to.
+  uint64 microgrid_id = 1;
+
+  // Sensors matching the request filters.
+  repeated frequenz.api.common.v1alpha8.microgrid.sensors.Sensor sensors = 2;
 }

--- a/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
+++ b/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
@@ -191,7 +191,8 @@ message GridpoolEnergySchedule {
   string name = 3;
 
   // The third-party balancing group involved in the scheduled energy exchange.
-  BalancingGroup counterparty_balancing_group = 4;
+  frequenz.api.common.v1alpha8.grid.BalancingGroup
+      counterparty_balancing_group = 4;
 
   // Delivery area in which the scheduled energy exchange applies.
   frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 5;

--- a/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
+++ b/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
@@ -93,6 +93,20 @@ enum GridpoolEnergyScheduleDirection {
   GRIDPOOL_ENERGY_SCHEDULE_DIRECTION_EXPORT = 2;
 }
 
+// Describes a use case for which a Gridpool assignment can participate.
+enum GridpoolAssignmentParticipationType {
+  // Unspecified participation type.
+  GRIDPOOL_ASSIGNMENT_PARTICIPATION_TYPE_UNSPECIFIED = 0;
+
+  // ENERGY_TRADING: The assignment participates in energy trading, supply,
+  // balancing, or settlement of scheduled and measured energy.
+  GRIDPOOL_ASSIGNMENT_PARTICIPATION_TYPE_ENERGY_TRADING = 1;
+
+  // ANCILLARY_SERVICES: The assignment participates in ancillary services or
+  // flex-market services, such as FCR, aFRR, or other grid-operator services.
+  GRIDPOOL_ASSIGNMENT_PARTICIPATION_TYPE_ANCILLARY_SERVICES = 2;
+}
+
 // Describes a structural assignment within a Gridpool.
 //
 // A Gridpool assignment represents one row of membership in a virtual
@@ -131,6 +145,44 @@ message GridpoolAssignment {
   // is assigned to the Gridpool independently of a directly managed Market
   // Location.
   optional uint64 microgrid_id = 2;
+
+  // Delivery area in which this assignment applies.
+  //
+  // The delivery area is defined in the Gridpool context because it describes
+  // where the assigned Market Location and/or Microgrid participates in the
+  // virtual balancing group.
+  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 3;
+
+  // Use-case-specific participation periods for this assignment.
+  //
+  // Different use cases can become active at different times. For example,
+  // energy trading may start before ancillary services, or ancillary services
+  // may end while the Market Location remains assigned for energy trading.
+  repeated GridpoolAssignmentParticipation participations = 4;
+}
+
+// Describes the validity period of a Gridpool assignment for a specific use
+// case.
+message GridpoolAssignmentParticipation {
+  // The use case for which this assignment participates.
+  GridpoolAssignmentParticipationType type = 1;
+
+  // Optional. Configured validity interval for this participation.
+  //
+  // If omitted, no explicit start or end date has been configured for this use
+  // case. Clients must not assume that the participation is inactive only
+  // because this field is unset.
+  //
+  // If set, the interval describes when this assignment is valid for the given
+  // use case. The interval is inclusive at `start_time` and exclusive at
+  // `end_time`.
+  frequenz.api.common.v1alpha8.types.Interval validity_period = 2;
+
+  // Optional. Timestamp at which this participation was cancelled.
+  //
+  // If set, this participation should no longer be considered effective from
+  // this timestamp onward, even if `validity_period.end_time` is later.
+  optional google.protobuf.Timestamp cancel_time = 3;
 }
 
 // A scheduled active-power value for one delivery period.
@@ -325,8 +377,8 @@ message ListGridpoolEnergySchedulesRequest {
     // If empty, no direction filtering is applied.
     repeated GridpoolEnergyScheduleDirection directions = 2;
 
-    // Optional. Return only schedule entries whose `start_time` falls within this
-    // interval.
+    // Optional. Return only schedule entries whose `start_time` falls within
+    // this interval.
     //
     // The interval is inclusive at `start_time` and exclusive at `end_time`.
     frequenz.api.common.v1alpha8.types.Interval delivery_time_interval = 3;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,11 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.8.0, < 0.9",
+  "frequenz-api-common >= 0.8.9, < 0.9",
   # We can't widen beyond the current value unless we bump the minimum
   # requirements too because of protobuf cross-version runtime guarantees:
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#major
-  "protobuf >= 6.31.1, < 8", # Do not widen beyond 8!
+  "protobuf >= 6.33.6, < 8", # Do not widen beyond 8!
   # We couldn't find any document with a spec about the cross-version runtime
   # guarantee for grpcio, so unless we find one in the future, we'll assume
   # major version jumps are not compatible


### PR DESCRIPTION
## Summary

This PR extends the Platform Assets API with market-topology and Gridpool-related metadata needed by trading, forecasting, reporting, and operational tooling. The PR also adds Gridpool energy schedules and microgrid sensor listing support.

## Changes

- Added `ListMarketTopologyRelations` for querying market-topology relations within the current enterprise scope.
- Added `MarketTopologyRelation` as the canonical relation model between Gridpools, Microgrids, and Market Locations.
- Added `MarketParticipation` and `MarketParticipationType` to describe use-case-specific participation of a market-topology relation.
- Added `ListGridpoolEnergySchedules` for retrieving static Gridpool energy schedules.
- Added `GridpoolEnergySchedule`, including counterparty balancing group, Gridpool and counterparty delivery areas, direction, validity period, cancellation timestamp, delivery duration, and scheduled active-power time series.
- Added `GridpoolEnergyScheduleDirection` to describe import/export direction from the perspective of the Frequenz balancing group.
- Added `ListMicrogridSensors` for listing sensors belonging to a specific microgrid.
- Updated service-level documentation to describe both platform asset metadata and market-topology metadata.
- Aligned request filters with the existing nested filter-message pattern used by the API.

## Notes

`MarketTopologyRelation` intentionally supports relations without a Gridpool. These represent Microgrid-to-Market-Location links used for deployment, metering validation, reporting comparison, or local optimization, and do not imply market participation.

If `gridpool_id` is set on a `MarketTopologyRelation`, the relation represents participation in a Gridpool context. In that case, `delivery_area` is required and `participations` may describe use-case-specific validity.

Gridpool energy schedules use a schedule-level `delivery_duration`. Each time-series entry contains only a start timestamp and applies until `start_time + delivery_duration`.

The API does not expose derived active/inactive schedule status. Clients can derive effective status from `validity_period`, `cancel_time`, and their own evaluation time.
