### PR TITLE
Bump frequenz-api-common to v0.8.11

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,6 @@
 # Frequenz Assets API Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
-## Bug Fixes
-
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* The minimum `frequenz-api-common` dependency version is now `0.8.11`.
+* `MarketTopologyRelation.market_location` has been renamed to `market_location_ref` to match the new message name in the common API.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,7 +117,7 @@ plugins:
           inventories:
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
-            - https://frequenz-floss.github.io/frequenz-api-common/v0.6/objects.inv
+            - https://frequenz-floss.github.io/frequenz-api-common/v0.8/objects.inv
             - https://grpc.github.io/grpc/python/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   # Note this plugin must be loaded after mkdocstrings to be able to use macros

--- a/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
+++ b/proto/frequenz/api/platformassets/v1alpha1/platformassets.proto
@@ -211,7 +211,7 @@ message MarketTopologyRelation {
   //
   // If `gridpool_id` is unset, this field links the Market Location to the
   // Microgrid without market participation.
-  frequenz.api.common.v1alpha8.grid.MarketLocation market_location = 2;
+  frequenz.api.common.v1alpha8.grid.MarketLocationRef market_location_ref = 2;
 
   // Optional. The Gridpool associated with this relation.
   //

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ requires = [
   # versions can't work with code that was generated with newer versions.
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#backwards
   "protobuf == 6.33.5",
-  "grpcio-tools == 1.80.0",
-  "grpcio == 1.80.0",
+  "grpcio-tools == 1.81.1",
+  "grpcio == 1.81.1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -45,7 +45,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.8.9, < 0.9",
+  "frequenz-api-common >= 0.8.11, < 0.9",
   # We can't widen beyond the current value unless we bump the minimum
   # requirements too because of protobuf cross-version runtime guarantees:
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#major
@@ -53,7 +53,7 @@ dependencies = [
   # We couldn't find any document with a spec about the cross-version runtime
   # guarantee for grpcio, so unless we find one in the future, we'll assume
   # major version jumps are not compatible
-  "grpcio >= 1.80.0, < 2", # Do not widen beyond 2!
+  "grpcio >= 1.81.1, < 2", # Do not widen beyond 2!
 ]
 dynamic = ["version"]
 
@@ -98,7 +98,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 9.1.1",
-  "pylint == 4.0.6",  
+  "pylint == 4.0.6",
   "frequenz-repo-config[extra-lint-examples] == 0.18.0",
 ]
 dev = [


### PR DESCRIPTION
Also fix the cross-reference links in the docs that used an outdated version.
